### PR TITLE
printing the board in user friendly format

### DIFF
--- a/app/pretty_print.py
+++ b/app/pretty_print.py
@@ -1,0 +1,71 @@
+# -*-coding: utf8-*-
+
+import app.board as board
+import app.logging_config as logconfig
+from app.config import Config
+import sys, os
+
+# Borders #
+VERT_L ="│"
+HORZ_L ="─"
+CUPLEFT ="┌"
+CUPRIGHT ="┐"
+CDWNLEFT ="└"
+CDWNRIGHT ="┘"
+T_UP ="┬"
+T_DOWN ="┴"
+WRDRIGHT ="├" 
+WRDLEFT ="┤"
+CROSS ="┼"
+
+WIDTH = 4
+
+topline = CUPLEFT + (HORZ_L * WIDTH + T_UP) * 11 + HORZ_L * WIDTH + CUPRIGHT
+midline = WRDRIGHT + (HORZ_L * WIDTH + CROSS) * 11 + HORZ_L * WIDTH + WRDLEFT
+botline = CDWNLEFT + (HORZ_L * WIDTH + T_DOWN) * 11 + HORZ_L * WIDTH + CDWNRIGHT
+
+def print_piece(p):
+    if p.owner == board.Owner.PLAYER:
+        r = next(iter(p.ranks))
+        r = "\033[34m%s\033[0m"%(str(r))
+    else:
+        r = "\033[31mX\033[0m"
+    return r
+
+def print_board(aboard):
+    drawn = ""
+
+    drawn += "  " + topline + "\n"
+    pieces = aboard.pieces_list
+
+    for i in range(5):
+        for j in range(12):
+            s = " "
+            if (j == 0):
+                drawn += chr(ord("A") + i) + " "
+                drawn += VERT_L
+            for p in pieces:
+                if p.position == (i, j):
+                    s = print_piece(p)
+            if(len(s) > WIDTH):
+                juster = len(s) + WIDTH - 1
+            else:
+                juster = WIDTH
+            drawn += s.center(juster, " ") + VERT_L
+            if (j == 11) and (i != 4):
+                drawn += "\n" + "  " + midline + "\n"
+
+    drawn += "\n" + "  " + botline + "\n"
+    drawn += "    1    2    3    4    5    6    7    8    9    10   11   12\n"
+    return drawn
+
+def draw_board(aboard):
+    if os.path.exists(logconfig.logs_dir):
+        buf = print_board(aboard)
+        config = Config()
+        fname = "player%d"%(config.turn) + ".draw"
+        fp = open(logconfig.logs_dir + "/" + fname, "a")
+        fp.write(aboard.serialize() + "\n" + buf + "\n")
+        fp.write("-" * 80 + "\n")
+        fp.close()
+

--- a/play4500
+++ b/play4500
@@ -2,6 +2,7 @@
 
 from app.config import Config
 import app.board_parser as board_parser
+import app.pretty_print as pp
 import app.message as message
 import app.io as io
 import app.board as board
@@ -37,6 +38,7 @@ def main():
         if isinstance(msg, message.MoveMessage):
             game_board = game_board.update(msg)
             game_board.dump_debug_board()
+            pp.draw_board(game_board)
 
             if msg.player == config.turn:
                 continue


### PR DESCRIPTION
Added a script that prints the board in a human viewable format on the command line. It will draw the board for player 1 and 2 in logs/player#.draw only if the logs folder exists. It will draw the board everytime there is a move message. Here is sample output:
http://i.imgur.com/b8erkXh.png
